### PR TITLE
Fix deprecation warnings

### DIFF
--- a/granian/asgi.py
+++ b/granian/asgi.py
@@ -34,7 +34,7 @@ class LifespanProtocol:
             if self.failure_startup or self.failure_shutdown:
                 return
             self.unsupported = True
-            logger.warn(
+            logger.warning(
                 'ASGI Lifespan errored, continuing without Lifespan support '
                 '(to avoid Lifespan completely use "asginl" interface)'
             )

--- a/granian/server.py
+++ b/granian/server.py
@@ -688,7 +688,7 @@ class Granian:
             spawn_target = default_spawners[self.interface]
             if sys.platform == 'win32' and self.workers > 1:
                 self.workers = 1
-                logger.warn(
+                logger.warning(
                     'Due to a bug in Windows unblocking socket implementation '
                     "granian can't support multiple workers on this platform. "
                     'Number of workers will now fallback to 1.'


### PR DESCRIPTION
## Summary
- replace deprecated `logger.warn` calls with `logger.warning`

## Testing
- `ruff check granian`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414bf13e0c8326951eae15dfe745ec